### PR TITLE
Omit ctrlTTY when interactive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/node_modules.DS_Store
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -52,8 +52,9 @@ const program = command(
     const cmdArgs = cmd.argv
 
     try {
+      const outputOpts = yes ? false : { ctrlTTY: false }
       await output(
-        false,
+        outputOpts,
         init(link, {
           dir,
           cwd,


### PR DESCRIPTION
Mirrors https://github.com/holepunchto/pear/pull/1004

Possible we should add this check somewhere else so always handled like this?